### PR TITLE
Print usage when -h, -help, or --help are invoked

### DIFF
--- a/skicka.go
+++ b/skicka.go
@@ -2475,7 +2475,7 @@ func main() {
 		"Configuration file")
 	vb := flag.Bool("verbose", false, "Enable verbose output")
 	dbg := flag.Bool("debug", false, "Enable debugging output")
-
+	flag.Usage = usage
 	flag.Parse()
 
 	if len(flag.Args()) == 0 {
@@ -2504,7 +2504,7 @@ func main() {
 	case "init":
 		createConfigFile(*configFilename)
 		return
-	case "help", "-h", "-help", "--help":
+	case "help":
 		usage()
 		return
 	}


### PR DESCRIPTION
Addresses #25 

The Usage var in the flag package defines the function that is called
when the flag -help or -h is called but no help flag is defined.  The
flag.Usage variable can be reassigned to another function if an
alternate function should be invoked, which is what this commit does.
If "-h", "--h", "-help", "--help" or "help" is typed as the command line
argument, "usage()" is invoked.
