### PR TITLE
Run the progressbar based on file transfer size

### DIFF
--- a/skicka.go
+++ b/skicka.go
@@ -1857,7 +1857,8 @@ func syncHierarchyDown(drivePath string, localPath string,
 		} else {
 			needsDownload, err := fileNeedsDownload(filePath, driveFilename, driveFile, ignoreTimes)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "skicka: error determining if file %s should be downloaded.\n", driveFilename)
+				fmt.Fprintf(os.Stderr, "skicka: error determining if file %s should "+
+					"be downloaded: %v\n", driveFilename, err)
 				os.Exit(1)
 			}
 			if needsDownload {


### PR DESCRIPTION
This addresses Issue #15.  Now both uploads and downloads display progress 
based on the total number of bytes transferred out of the total bytes to 
be transferred.  In order to accomplish this, the determination of what would be sync'd before the actual sync has to be separated into its own logical components, whereas currently in master the logic to transport the bits up and down and the determiner of what is going up and down are intertwined.  That's why there's a decent amount of moving around of code.
