### PR TITLE
Use os.Chmod for Windows. Fixes #77

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,5 @@
 # Please keep the list sorted.
 
 Google Inc.
+Bradley Grainger
 Nathan Guerin

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,3 +27,4 @@ Matt Pharr <mpharr@google.com>
 Daniel Margolis <dmargolis@google.com>
 Nathan Guerin <nathan.guerin@gmail.com>
 Austin Dizzy <dizzy@wow.com>
+Bradley Grainger <bgrainger@gmail.com>

--- a/download.go
+++ b/download.go
@@ -571,7 +571,7 @@ func getLocalWriterForDriveFile(localPath string,
 	if err != nil {
 		permissions = 0644
 	}
-	err = f.Chmod(permissions)
+	err = os.Chmod(localPath, permissions)
 	if err != nil {
 		_ = f.Close()
 		return nil, err


### PR DESCRIPTION
File.Chmod isn't implemented on Windows and fails at runtime.