### PR TITLE
Close disk cache file immediately after use. Fixes #75

### DIFF
--- a/gdrive/gdrive.go
+++ b/gdrive/gdrive.go
@@ -649,6 +649,7 @@ func (gd *GDrive) getIdToFile(filename string) (map[string]*File, error) {
 		if err := decoder.Decode(&idToFile); err != nil {
 			return nil, err
 		}
+		f.Close()
 		gd.debug("Done reading file cache from disk")
 	} else {
 		// No metadata available locally; pull the entire history from Drive.


### PR DESCRIPTION
The `defer f.Close` call is still there, so this ends up closing the file twice (which doesn't appear to cause a problem). 

Let me know if you think lines 622-657 should be extracted out to a separate method (so that `defer` will be sufficient); I couldn't decide if that would improve readability/maintainability or not.