### PR TITLE
Tidy output & include more example regex

### DIFF
--- a/skicka.go
+++ b/skicka.go
@@ -730,6 +730,16 @@ func createConfigFile(filename string) {
         ; line for each such regular expression.
 	;ignored-regexp="\\.o$"
 	;ignored-regexp=~$
+	;ignored-regexp="\\._"
+	;ignored-regexp="RECYCLE\\.BIN"
+	;ignored-regexp="Thumbs\\.db$"
+	;ignored-regexp="\\.git"
+	;ignored-regexp="\\.(mp3|wma|aiff)$"
+	;ignored-regexp="\\.~lock\\..*$"
+	;ignored-regexp="~\\$"
+	;ignored-regexp="\\.DS_Store$"
+    	;ignored-regexp="desktop.ini"
+
 	;
 	; To limit upload bandwidth, you can set the maximum (average)
 	; bytes per second that will be used for uploads

--- a/upload.go
+++ b/upload.go
@@ -468,7 +468,7 @@ func fileNeedsUpload(localPath, drivePath string, stat os.FileInfo,
 	for _, re := range config.Upload.Ignored_Regexp {
 		match, err := regexp.MatchString(re, localPath)
 		if match == true {
-			fmt.Fprintf(os.Stderr, "skicka: %s: ignoring file, which "+
+			verbose.Printf("skicka: %s: ignoring file, which "+
 				"matches regexp \"%s\".\n", localPath, re)
 			return false, nil
 		}
@@ -737,7 +737,7 @@ func compileUploadFileTree(localPath, drivePath string,
 		if isSymlink(stat) {
 			localPath, stat, err = resolveSymlinks(localPath, stat, &maxSymlinkDepth)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "skicka: %s", err)
+				verbose.Printf("skicka: %s", err)
 				nUploadErrors++
 				return nil, nUploadErrors
 			}


### PR DESCRIPTION
I'm a heavy user, and these are my patches, thought I would request a pull so others can benefit. 

The filter examples are important, it took me far too long to understand the syntax, coming from pcre-land. I figure others might struggle etc.

The verbose log changes, are because once the filters are working great, you don't want to see the notice for every file that you specifically said, "Don't upload".. However, being able to find the messages again by turning on the -verbose flag makes sense (to me). 
Also, I was seeing loads of symlink messages, which weren't errors to me, so I also hide them. 

Anyway, cheers for an awesome tool!